### PR TITLE
Update work flow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,24 +1,30 @@
 name: Android CI
 on:
   push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+    branches: [ master ]
+    pull_request:
+      branches: [ master ]
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  apk:
+    name: Generate APK
+    runs-on: ubuntu-18.04
+
     steps:
-      - uses: actions/checkout@v2
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v1
+      - name: set up JDK
+        uses: actions/checkout@v2
         with:
-          java-version: 1.8
-      - name: Build with Gradle
-        run: |
-          chmod +x gradlew
-          ./gradlew assembleDebug --stacktrace
-      - name: Upload APK
-        uses: actions/upload-artifact@v1
+          java-version: 11.0.3
+
+      - name: Grant Permission to Execute
+        run: chmod +x gradlew
+
+      - name: Build debug APK
+        run: bash ./gradlew assembleDebug --stacktrace
+
+      - name: Upload APK to Github Artifacts
+        uses: actions/upload-artifact@v2
         with:
-          name: apk
+          name: app
           path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Android Gradle plugin requires Java 11 to run. You are currently using Java 1.8.
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.